### PR TITLE
Improve error handling in case of VAT assessment/verification failures

### DIFF
--- a/oscar_vat_moss/checkout/session.py
+++ b/oscar_vat_moss/checkout/session.py
@@ -16,15 +16,12 @@ class CheckoutSessionMixin(session.CheckoutSessionMixin):
         if assess_tax:
             try:
                 vat.apply_to(submission)
-            except vat.VATAssessmentException as e:
-                raise exceptions.FailedPreCondition(
-                    url=reverse('checkout:shipping-address'),
-                    message=_(str(e))
-                )
-
-            # Recalculate order total to ensure we have a tax-inclusive total
-            submission['order_total'] = self.get_order_totals(
-                submission['basket'], submission['shipping_charge'])
+                # Recalculate order total to ensure we have a
+                # tax-inclusive total
+                submission['order_total'] = self.get_order_totals(
+                    submission['basket'], submission['shipping_charge'])
+            except vat.VATAssessmentException:
+                pass
         return submission
 
     def check_a_valid_shipping_address_is_captured(self):

--- a/oscar_vat_moss/checkout/session.py
+++ b/oscar_vat_moss/checkout/session.py
@@ -10,9 +10,9 @@ class CheckoutSessionMixin(session.CheckoutSessionMixin):
         submission = super(CheckoutSessionMixin, self).build_submission(
             **kwargs)
 
-        assess_tax = (submission['shipping_method']
-                      and submission['shipping_address']
-                      and submission['shipping_address'].phone_number)
+        assess_tax = (submission['shipping_method'] and
+                      submission['shipping_address'] and
+                      submission['shipping_address'].phone_number)
         if assess_tax:
             try:
                 vat.apply_to(submission)

--- a/oscar_vat_moss/checkout/session.py
+++ b/oscar_vat_moss/checkout/session.py
@@ -10,7 +10,10 @@ class CheckoutSessionMixin(session.CheckoutSessionMixin):
         submission = super(CheckoutSessionMixin, self).build_submission(
             **kwargs)
 
-        if submission['shipping_address'] and submission['shipping_method']:
+        assess_tax = (submission['shipping_method']
+                      and submission['shipping_address']
+                      and submission['shipping_address'].phone_number)
+        if assess_tax:
             try:
                 vat.apply_to(submission)
             except vat.VATAssessmentException as e:

--- a/oscar_vat_moss/checkout/session.py
+++ b/oscar_vat_moss/checkout/session.py
@@ -27,6 +27,19 @@ class CheckoutSessionMixin(session.CheckoutSessionMixin):
                 submission['basket'], submission['shipping_charge'])
         return submission
 
+    def check_a_valid_shipping_address_is_captured(self):
+        super(CheckoutSessionMixin, self)
+        shipping_address = self.get_shipping_address(
+            basket=self.request.basket)
+        try:
+            vat.lookup_vat_for_shipping_address(shipping_address)
+        except vat.VATAssessmentException as e:
+            message = _("%s. Please try again." % str(e))
+            raise exceptions.FailedPreCondition(
+                url=reverse('checkout:shipping-address'),
+                message=message
+            )
+
     def get_context_data(self, **kwargs):
         ctx = super(CheckoutSessionMixin, self).get_context_data(**kwargs)
 

--- a/oscar_vat_moss/checkout/session.py
+++ b/oscar_vat_moss/checkout/session.py
@@ -13,7 +13,7 @@ class CheckoutSessionMixin(session.CheckoutSessionMixin):
         if submission['shipping_address'] and submission['shipping_method']:
             try:
                 vat.apply_to(submission)
-            except vat.NonMatchingVATINException as e:
+            except vat.VATAssessmentException as e:
                 raise exceptions.FailedPreCondition(
                     url=reverse('checkout:shipping-address'),
                     message=_(str(e))

--- a/oscar_vat_moss/vat.py
+++ b/oscar_vat_moss/vat.py
@@ -13,7 +13,7 @@ VERIFICATIONS_NEEDED = 2
 
 
 def apply_to(submission):
-    rate = lookup_vat(submission)
+    rate = lookup_vat_for_submission(submission)
 
     for line in submission['basket'].all_lines():
         line_tax = calculate_tax(
@@ -28,23 +28,32 @@ def apply_to(submission):
         shipping_charge.excl_tax, rate)
 
 
-def lookup_vat(submission):
+def lookup_vat_for_submission(submission):
     shipping_address = submission['shipping_address']
     # Use getattr here so we can default to empty string for
     # non-existing fields.
     city = getattr(shipping_address, 'line4', '')
+    company = getattr(shipping_address, 'line1', '')
     country = getattr(shipping_address, 'country', '')
     postcode = getattr(shipping_address, 'postcode', '')
     phone_number = getattr(shipping_address, 'phone_number', '')
     vatin = getattr(shipping_address, 'vatin', '')
 
+    return lookup_vat(city,
+                      company,
+                      country,
+                      postcode,
+                      phone_number,
+                      vatin)
+
+
+def lookup_vat(city, company, country, postcode, phone_number, vatin):
     verifications = 0
     address_vat_rate = None
     phone_vat_rate = None
 
     if vatin:
-        shipping_company = getattr(shipping_address, 'line1', '')
-        rate = lookup_vat_by_vatin(vatin, shipping_company)
+        rate = lookup_vat_by_vatin(vatin, company)
         # TODO: Test if we have our own VATIN, and do apply VAT if
         # shipping country is the same as the store's own country.
         return rate

--- a/oscar_vat_moss/vat.py
+++ b/oscar_vat_moss/vat.py
@@ -9,6 +9,8 @@ import vat_moss.phone_number
 
 from oscar_vat_moss.util import u
 
+VERIFICATIONS_NEEDED = 2
+
 
 def apply_to(submission):
     rate = lookup_vat(submission)
@@ -65,10 +67,13 @@ def lookup_vat(submission):
     except:
         pass
 
-    # TODO: Raise an error if we don't have 2 verifications
+    if verifications < VERIFICATIONS_NEEDED:
+        raise VATAssessmentException()
 
-    # TODO: Verify here that the calculated rates actually match
-    return address_vat_rate or phone_vat_rate
+    if address_vat_rate != phone_vat_rate:
+        raise VATAssessmentException()
+
+    return address_vat_rate
 
 
 def lookup_vat_by_vatin(vatin, company_name):
@@ -117,7 +122,11 @@ def calculate_tax(price, rate):
     return tax.quantize(D('0.01'))
 
 
-class NonMatchingVATINException(Exception):
+class VATAssessmentException(Exception):
+    pass
+
+
+class NonMatchingVATINException(VATAssessmentException):
 
     def __init__(self, vatin, company_name):
         self.message = _('VATIN %s does not match company name %s' %

--- a/oscar_vat_moss/vat.py
+++ b/oscar_vat_moss/vat.py
@@ -148,7 +148,11 @@ def calculate_tax(price, rate):
 
 
 class VATAssessmentException(Exception):
-    pass
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return repr(self.message)
 
 
 class VATAssessmentUnavailableException(VATAssessmentException):
@@ -162,6 +166,3 @@ class NonMatchingVATINException(VATAssessmentException):
                          (vatin, company_name))
         self.vatin = vatin
         self.company_name = company_name
-
-    def __str__(self):
-        return self.message

--- a/tests/test_vat.py
+++ b/tests/test_vat.py
@@ -19,12 +19,12 @@ class AddressTest(unittest.TestCase):
          },                            D('0.23')),
     )
 
-    def test_lookup_vat_by_address(self):
+    def test_lookup_vat_by_city(self):
         for addr, expected_rate in self.ADDRESSES:
             country_code = addr.get('country')
             postcode = addr.get('postcode')
             city = addr.get('line4')
-            result_rate = vat.lookup_vat_by_address(country_code, postcode, city)
+            result_rate = vat.lookup_vat_by_city(country_code, postcode, city)
             self.assertEqual(result_rate,
                              expected_rate,
                              msg="Unexpected VAT rate returned for %s: %s" % (addr, result_rate))


### PR DESCRIPTION
If in process of checking the VATIN against the company name we
hit NonMatchingVATINException, bounce the user back to the shipping
address page with an explanatory notice.