### PR TITLE
Add a "fixed", per-user VAT strategy

### DIFF
--- a/oscar_vat_moss/partner/strategy.py
+++ b/oscar_vat_moss/partner/strategy.py
@@ -3,9 +3,18 @@ from oscar.apps.partner import strategy
 
 class Selector(object):
     def strategy(self, request=None, user=None, **kwargs):
-        return VATStrategy(request)
+        return DeferredVATStrategy(request)
 
 
-class VATStrategy(strategy.UseFirstStockRecord, strategy.DeferredTax,
-                  strategy.StockRequired, strategy.Structured):
+class DeferredVATStrategy(strategy.UseFirstStockRecord, strategy.DeferredTax,
+                          strategy.StockRequired, strategy.Structured):
+    """Strategy that defers tax assessment until checkout.
+
+    With this strategy, your users always see a tax-free amount and
+    taxes are added to their invoice on checkout.
+
+    Requires that a CheckoutSessionMixin be added to your checkout
+    app, which then applies taxes once the user has given their
+    shipping address.
+    """
     pass

--- a/oscar_vat_moss/partner/strategy.py
+++ b/oscar_vat_moss/partner/strategy.py
@@ -18,6 +18,16 @@ class DeferredVATSelector(object):
         return DeferredVATStrategy(request)
 
 
+class PerUserVATSelector(object):
+    """Selector that returns the PerUserVATStrategy.
+
+    To use this selector directly:
+    from oscar_vat_moss.apps.partner import PerUserVATSelector as Selector"""
+
+    def strategy(self, request=None, user=None, **kwargs):
+        return PerUserVATStrategy(request)
+
+
 class DeferredVATStrategy(strategy.UseFirstStockRecord, strategy.DeferredTax,
                           strategy.StockRequired, strategy.Structured):
     """Strategy that defers tax assessment until checkout.

--- a/oscar_vat_moss/partner/strategy.py
+++ b/oscar_vat_moss/partner/strategy.py
@@ -8,7 +8,12 @@ from decimal import Decimal as D
 import logging
 
 
-class Selector(object):
+class DeferredVATSelector(object):
+    """Selector that returns the DeferredVATStrategy.
+
+    To use this selector directly:
+    from oscar_vat_moss.apps.partner import DeferredVATSelector as Selector"""
+
     def strategy(self, request=None, user=None, **kwargs):
         return DeferredVATStrategy(request)
 

--- a/oscar_vat_moss/partner/strategy.py
+++ b/oscar_vat_moss/partner/strategy.py
@@ -1,4 +1,11 @@
+from django.conf import settings
+
 from oscar.apps.partner import strategy
+
+from oscar_vat_moss import vat
+
+from decimal import Decimal as D
+import logging
 
 
 class Selector(object):
@@ -18,3 +25,35 @@ class DeferredVATStrategy(strategy.UseFirstStockRecord, strategy.DeferredTax,
     shipping address.
     """
     pass
+
+
+class PerUserVATStrategy(strategy.UseFirstStockRecord, strategy.FixedRateTax,
+                         strategy.StockRequired, strategy.Structured):
+    """Strategy that applies a "fixed" VAT rate to your products.
+
+    With this strategy, your users always see tax-included amounts for
+    your home territory. After they register and give an address, they
+    switch to their locally applicable tax rate."""
+
+    def get_rate(self, product, stockrecord):
+        """Fetches a tax rate, given a product and stockrecord"""
+
+        # The strategy.Base superclass sets self.user only if the user
+        # is authenticated
+        try:
+            return vat.lookup_vat_for_user(self.user)
+        except:
+            # Unable to look up user address or VAT rate, use defaults
+            pass
+
+        # We haven't been able to lookup a VAT rate for the user, use
+        # store defaults instead. If all fails, revert to a tax rate of 0.
+        try:
+            return vat.lookup_vat_by_city(
+                settings.VAT_MOSS_STORE_COUNTRY_CODE,
+                settings.VAT_MOSS_STORE_POSTCODE,
+                settings.VAT_MOSS_STORE_CITY)
+        except NameError:
+            logging.warn('Unable to set default VAT rate for store, '
+                         'defaulting to 0.')
+            return D('0.00')

--- a/oscar_vat_moss/vat.py
+++ b/oscar_vat_moss/vat.py
@@ -34,6 +34,14 @@ def lookup_vat_for_submission(submission):
     return lookup_vat_for_address(shipping_address)
 
 
+def lookup_vat_for_user(user):
+    # If we have an address that is marked as the default
+    # shipping address, we'll use that. Otherwise,
+    # randomly use the first address.
+    tax_address = self.user.addresses.order_by('-is_default_for_shipping')[0]
+    return lookup_vat_for_address(tax_address)
+
+
 def lookup_vat_for_address(address):
     # Use getattr here so we can default to empty string for
     # non-existing fields.

--- a/oscar_vat_moss/vat.py
+++ b/oscar_vat_moss/vat.py
@@ -38,7 +38,7 @@ def lookup_vat_for_user(user):
     # If we have an address that is marked as the default
     # shipping address, we'll use that. Otherwise,
     # randomly use the first address.
-    tax_address = self.user.addresses.order_by('-is_default_for_shipping')[0]
+    tax_address = user.addresses.order_by('-is_default_for_shipping')[0]
     return lookup_vat_for_address(tax_address)
 
 

--- a/tests/test_vat.py
+++ b/tests/test_vat.py
@@ -145,6 +145,51 @@ class PhoneNumberAddressTest(unittest.TestCase):
                                              num,
                                              None)
 
+class UserTest(unittest.TestCase):
+
+    def test_valid_user(self):
+        address = Mock()
+        address.country = Mock()
+        address.country.code = 'AT'
+        address.line4 = 'Vienna'
+        address.postcode = '1010'
+        address.phone_number = '+43 1 234 5678'
+        address.line1 = 'hastexo Professional Services GmbH'
+        address.vatin = ''
+        user = Mock()
+        user.addresses = Mock()
+        user.addresses.order_by = Mock(return_value=[address])
+
+        result_rate = vat.lookup_vat_for_user(user)
+        self.assertEqual(result_rate,
+                         D('0.20'))
+
+        address.vatin = 'ATU66688202'
+        result_rate = vat.lookup_vat_for_user(user)
+        self.assertEqual(result_rate,
+                         D('0.00'))
+
+    def test_invalid_user(self):
+        address = Mock()
+        address.country = Mock()
+        address.country.code = 'AT'
+        address.line4 = 'Vienna'
+        address.postcode = '1010'
+        address.phone_number = '+49 911 234 5678'
+        address.line1 = 'hastexo Professional Services GmbH'
+        address.vatin = ''
+        user = Mock()
+        user.addresses = Mock()
+        user.addresses.order_by = Mock(return_value=[address])
+
+        with self.assertRaises(vat.VATAssessmentException):
+            result_rate = vat.lookup_vat_for_user(user)
+
+        address.vatin = 'ATU66688999'
+        with self.assertRaises(vat.VATAssessmentException):
+            result_rate = vat.lookup_vat_for_user(user)
+
+
 class SubmissionTest(unittest.TestCase):
 
     def test_valid_submission(self):


### PR DESCRIPTION
The DeferredTax tax assessment is notoriously error prone and difficult to deal with. However, the strategy selector and the FixedRateTax mix-in allow us to:

- Display VAT in the user's applicable rate, if they have given us a shipping address;
- Display VAT in the store's default rate otherwise.