### PR TITLE
Move fields.py out of app-specific directory, add convenience method

### DIFF
--- a/oscar_vat_moss/address/models.py
+++ b/oscar_vat_moss/address/models.py
@@ -1,12 +1,7 @@
-from oscar.apps.address import models
-from django.utils.translation import ugettext_lazy as _
-
-from . import fields
+from oscar.apps.address.abstract_models import AbstractUserAddress
+from oscar_vat_moss import fields
 
 
-class AbstractShippingAddress(models.AbstractShippingAddress):
-    vatin = fields.VATINField(
-        _('VAT Identification Number (VATIN)'),
-        blank=True,
-        help_text=_('Required if you are associated with a business '
-                    'registered for VAT in the European Union.'))
+class VATINUserAddress(AbstractUserAddress):
+
+    vatin = fields.vatin()

--- a/oscar_vat_moss/fields.py
+++ b/oscar_vat_moss/fields.py
@@ -3,9 +3,7 @@ from django.core import validators
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 from oscar.forms import fields
-
 import vat_moss.id
-
 from oscar_vat_moss.util import u
 
 # The longest VAT IDs are currently 2-letter country code + 15
@@ -13,19 +11,33 @@ from oscar_vat_moss.util import u
 DEFAULT_MAX_LENGTH = 32
 
 
+def vatin(verbose_name=_('VAT Identification Number (VATIN)'),
+          name='vatin',
+          verify_exists=None,
+          blank=True,
+          help_text=_('Required if you are associated with a business '
+                      'registered for VAT in the European Union.')):
+    """Convenience method to return a properly configured VATIN field."""
+    return VATINField(verbose_name=verbose_name,
+                      name=name,
+                      verify_exists=verify_exists,
+                      blank=blank,
+                      help_text=help_text)
+
+
 class VATINField(CharField):
     def __init__(self, verbose_name=None, name=None,
                  verify_exists=None, **kwargs):
         kwargs['max_length'] = kwargs.get('max_length', DEFAULT_MAX_LENGTH)
         CharField.__init__(self, verbose_name, name, **kwargs)
-        validator = VATINValidator()
+        validator = VATINValidator(None)
         self.validators.append(validator)
 
     def formfield(self, **kwargs):
         # As with CharField, this will cause VATIN validation to be performed
         # twice.
         defaults = {
-            'form_class': fields.VATINField,
+            'form_class': fields.CharField,
         }
         defaults.update(kwargs)
         return super(CharField, self).formfield(**defaults)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,0 +1,53 @@
+import unittest
+from decimal import Decimal as D
+from oscar_vat_moss.fields import *  # noqa
+from django.core.exceptions import ValidationError
+
+
+class VATINValidatorTest(unittest.TestCase):
+    VALID_VATINS = (
+        # VATIN         # Company name
+        ('ATU66688202', 'hastexo Professional Services GmbH'),
+        ('ATU66688202', 'HASTEXO PROFESSIONAL SERVICES GMBH'),
+        ('ATU66688202', 'hastexo Professional Services GmbH (Procurement Department)'),
+        )
+    INVALID_VATINS = (
+        # VATIN         # Incorrect company name
+        ('ATU66688999', 'Example, Inc.'),
+        ('ATU99999999', 'Acme, Inc'),
+        )
+
+    def test_valid_vatin(self):
+        validator = VATINValidator(None)
+        for vatin, name in self.VALID_VATINS:
+            # Just ensure this doesn't fail
+            validator.validate_vatin(vatin)
+            # validator is also callable
+            validator(vatin)
+
+    def test_invalid_vatin(self):
+        validator = VATINValidator(None)
+        for vatin, name in self.INVALID_VATINS:
+            with self.assertRaises(ValidationError):
+                validator.validate_vatin(vatin)
+
+            with self.assertRaises(ValidationError):
+                # validator is also callable
+                validator(vatin)
+
+
+class VATINFieldTest(unittest.TestCase):
+    
+    def test_default_properties(self):
+        field = VATINField()
+        validator_classes = [ v.__class__ for v in field.validators ]
+        self.assertTrue(VATINValidator in validator_classes)
+        self.assertEqual(field.max_length, DEFAULT_MAX_LENGTH)
+
+    def test_convenience_method(self):
+        field = vatin()
+        validator_classes = [ v.__class__ for v in field.validators ]
+        self.assertTrue(VATINValidator in validator_classes)
+        self.assertEqual(field.max_length, DEFAULT_MAX_LENGTH)
+        self.assertEqual(field.name,'vatin')
+        self.assertTrue(field.blank)


### PR DESCRIPTION
The VATINField must be used by several address-related object types:

- UserAddress (in address)
- PartnerAddress (in partner)
- ShippingAddress and BillingAddress (in order)

To facilitate adding the same field to the different models, add a
convenience method, fields.vatin(), that will return a properly
configured field object.