### PR TITLE
Correctly handle an empty address form submission

### DIFF
--- a/oscar_vat_moss/address/forms.py
+++ b/oscar_vat_moss/address/forms.py
@@ -18,7 +18,11 @@ class UserAddressForm(CoreUserAddressForm):
         # Grab the interesting fields from the form
         company = data.get('line1')
         city = data.get('line4')
-        country_code = data.get('country').code
+        country = data.get('country')
+        if country:
+            country_code = data.get('country').code
+        else:
+            country_code = ''
         postcode = data.get('postcode')
         phone_number = data.get('phone_number')
         vatin = data.get('vatin')

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -21,6 +21,12 @@ class UserAddressFormTest(TestCase):
         self.de = Country.objects.create(
             iso_3166_1_a2='DE', name="GERMANY")
 
+    def test_empty_address(self):
+        data = dict(user=self.johndoe)
+        form = UserAddressForm(self.johndoe,
+                               data)
+        self.assertFalse(form.is_valid())
+
     def test_valid_address(self):
         # Is a valid address identified correctly?
         data = dict(


### PR DESCRIPTION
If the user selects no country, the Country object available as form
data is None, which means we can't retrieve its code.