### PR TITLE
Correctly assess VAT if VATIN country matches store country

### DIFF
--- a/oscar_vat_moss/address/forms.py
+++ b/oscar_vat_moss/address/forms.py
@@ -42,6 +42,14 @@ class UserAddressForm(CoreUserAddressForm):
             except vat.CountryInvalidForVATINException as c:
                 self.add_error('country', str(c))
                 self.add_error('vatin', str(c))
+            except vat.VATINCountrySameAsStoreException:
+                # The VATIN is valid, though we still have to charge
+                # VAT as the VATIN is from the same country as the
+                # store.
+                #
+                # TODO: It would be great if we could flag this to the
+                # user via the messages framework.
+                pass
             except Exception as e:
                 self.add_error('vatin', str(e))
 

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -1,11 +1,12 @@
-import unittest
+from django.test import TestCase
+from django.test.utils import override_settings
 from decimal import Decimal as D
 from oscar_vat_moss.partner.strategy import *  # noqa
 
 from mock import Mock
 
 
-class DeferredVATSelectorTest(unittest.TestCase):
+class DeferredVATSelectorTest(TestCase):
 
     def test_selector(self):
         selector = DeferredVATSelector()
@@ -16,7 +17,7 @@ class DeferredVATSelectorTest(unittest.TestCase):
             strategy.getRate(None, None)
 
 
-class PerUserVATSelectorTest(unittest.TestCase):
+class PerUserVATSelectorTest(TestCase):
 
     def test_selector(self):
         selector = PerUserVATSelector()
@@ -26,9 +27,10 @@ class PerUserVATSelectorTest(unittest.TestCase):
         self.assertTrue(hasattr(strategy, 'get_rate'))
 
 
-class PerUserVATStrategyTest(unittest.TestCase):
+class PerUserVATStrategyTest(TestCase):
 
-    def test_valid_user(self):
+    @override_settings(VAT_MOSS_STORE_COUNTRY_CODE='DE')
+    def test_valid_user_reverse_charge(self):
         address = Mock()
         address.country = Mock()
         address.country.code = 'AT'
@@ -52,6 +54,39 @@ class PerUserVATStrategyTest(unittest.TestCase):
                          D('0.20'))
 
         address.vatin = 'ATU66688202'
+        # Valid VATIN, but same country as store: should apply reverse
+        # charge rules, zero VAT.
         result_rate = strategy.get_rate(None, None)
         self.assertEqual(result_rate,
                          D('0.00'))
+
+    @override_settings(VAT_MOSS_STORE_COUNTRY_CODE='AT')
+    def test_valid_user_noreverse_charge(self):
+        address = Mock()
+        address.country = Mock()
+        address.country.code = 'AT'
+        address.line4 = 'Vienna'
+        address.postcode = '1010'
+        address.phone_number = '+43 1 234 5678'
+        address.line1 = 'hastexo Professional Services GmbH'
+        address.vatin = ''
+
+        request = Mock()
+        request.user = Mock()
+        request.user.addresses = Mock()
+        request.user.addresses.order_by = Mock(return_value=[address])
+        request.user.is_authenticated = Mock(return_value=True)
+
+        selector = PerUserVATSelector()
+        strategy = selector.strategy(request=request)
+
+        result_rate = strategy.get_rate(None, None)
+        self.assertEqual(result_rate,
+                         D('0.20'))
+
+        address.vatin = 'ATU66688202'
+        # Valid VATIN, but same country as store: should return normal
+        # VAT rate.
+        result_rate = strategy.get_rate(None, None)
+        self.assertEqual(result_rate,
+                         D('0.20'))


### PR DESCRIPTION
If a user provides us with a VATIN, but it applies to the same country
as the one the store is in, reverse charge does not apply and we
always have to charge regular VAT.

Also, let test classes inherit from django.test.TestCase not
unittest.TestCase, so that we can use the override_settings decorator.