### PR TITLE
Add missing test coverage on UserAddressForm, VAT assessment

### DIFF
--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -92,6 +92,22 @@ class UserAddressFormTest(TestCase):
                                data)
         self.assertFalse(form.is_valid())
 
+    def test_vatin_wrong_country(self):
+        # Is an invalid VATIN identified correctly?
+        data = dict(
+            user=self.hansmueller,
+            first_name="Hans",
+            last_name="Müller",
+            line1="hastexo Professional Services GmbH",
+            line4="Wien",
+            postcode="1010",
+            country=self.uk.iso_3166_1_a2,
+            vatin='ATU66688202',
+        )
+        form = UserAddressForm(self.hansmueller,
+                               data)
+        self.assertFalse(form.is_valid())
+
     def test_non_matching_vatin(self):
         # Is a VATIN that is correct, but doesn't match the company
         # name, identified correctly?

--- a/tests/test_vat.py
+++ b/tests/test_vat.py
@@ -127,6 +127,16 @@ class PhoneNumberAddressTest(TestCase):
           'country': 'AT',
           'postcode': 6691},
          "+43 1 123 4567"),
+        # Empty phone number, only able to check address
+        ({'line4': 'Jungholz',
+          'country': 'AT',
+          'postcode': 6691},
+         ""),
+        # Empty phone number, only able to check phone number
+        ({ 'line4': '',
+           'country': 'DE',
+           'postcode': '' },
+         "+43 123 456 789"),
     )
 
     def test_valid_combination(self):


### PR DESCRIPTION
We previously hadn't checked for a VATIN that didn't match the form's country.